### PR TITLE
Correcting legacy runs transposed output

### DIFF
--- a/app.py
+++ b/app.py
@@ -868,7 +868,7 @@ def export_google_sheets(config: Config, export_data: dict) -> None:
         col_names=True,
     )
     d2g.upload(
-        df=detail_dataframe.transpose(),
+        df=detail_dataframe,
         gfile=config["google_sheets_key"],
         wks_name=f"output-{datetime.utcnow().date().isoformat()}",
         credentials=google_credentials,


### PR DESCRIPTION
Small changing concerning the 3rd spreadsheet output (legacy runs in the format output_2021_XX_YY). In the current version the output is transposed. I just dropped the .transpose() on the last d2g.upload().